### PR TITLE
Add is_match? method for one-off checks

### DIFF
--- a/lib/slide_rule/distance_calculator.rb
+++ b/lib/slide_rule/distance_calculator.rb
@@ -24,6 +24,11 @@ module SlideRule
       matches(obj, array, threshold).sort { |match| match[:distance] }.first
     end
 
+    def is_match?(obj_1, obj_2, threshold)
+      distance = calculate_distance(obj_1, obj_2)
+      distance < threshold
+    end
+
     def matches(obj, array, threshold)
       array.map do |item|
         distance = calculate_distance(obj, item)

--- a/spec/slide_rule/distance_calculator_spec.rb
+++ b/spec/slide_rule/distance_calculator_spec.rb
@@ -54,6 +54,35 @@ describe ::SlideRule::DistanceCalculator do
     end
   end
 
+  describe '#is_match?' do
+    let(:calculator) do
+      ::SlideRule::DistanceCalculator.new(
+        description: {
+          weight: 0.80,
+          type: :levenshtein
+        },
+        date: {
+          weight: 0.90,
+          type: :day_of_month
+        }
+      )
+    end
+
+    it 'returns true if there is a match' do 
+      example_1 = ExampleTransaction.new(description: 'Wells Fargo Dealer SVC', date: '2015-06-17')
+      example_2 = ExampleTransaction.new(description: 'Wells Fargo Dealer SVC', date: '2015-06-17')
+
+      expect(calculator.is_match?(example_1, example_2, 0.2)).to be(true)
+    end
+
+    it 'returns false if there is a match' do 
+      example_1 = ExampleTransaction.new(description: 'Wells Fargo Dealer SVC', date: '2015-06-17')
+      example_2 = ExampleTransaction.new(description: 'Taco Bell', date: '2015-06-17')
+
+      expect(calculator.is_match?(example_1, example_2, 0.2)).to be(false)
+    end
+  end
+
   describe '#calculate_distance' do
     context 'uses built-in calculator' do
       it 'should calculate perfect match' do


### PR DESCRIPTION
This adds a method that will just test to objects without an array. It has a boolean response, hence the predicate method.

@mattnichols @mmmries @abrandoned @liveh2o 
