### PR TITLE
Add options hash to calculators

### DIFF
--- a/lib/slide_rule/distance_calculator.rb
+++ b/lib/slide_rule/distance_calculator.rb
@@ -58,6 +58,7 @@ module SlideRule
     #   :attribute_name => {
     #     :weight => 0.90,
     #     :calculator => :distance_calculator,
+    #     :threshold => 30
     #   }
     # }
     def calculate_distance(i1, i2)
@@ -72,7 +73,7 @@ module SlideRule
       distances = @rules.map do |attribute, rule|
         val1 = i1.send(attribute)
         val2 = i2.send(attribute)
-        distance = rule[:calculator].calculate(val1, val2)
+        distance = rule[:calculator].calculate(val1, val2, rule)
         next { distance: distance.to_f, weight: rule[:weight] } unless distance.nil?
 
         nil

--- a/lib/slide_rule/distance_calculator.rb
+++ b/lib/slide_rule/distance_calculator.rb
@@ -70,11 +70,11 @@ module SlideRule
     private
 
     def calculate_weighted_distances(i1, i2)
-      distances = @rules.map do |attribute, rule|
+      distances = @rules.map do |attribute, options|
         val1 = i1.send(attribute)
         val2 = i2.send(attribute)
-        distance = rule[:calculator].calculate(val1, val2, rule)
-        next { distance: distance.to_f, weight: rule[:weight] } unless distance.nil?
+        distance = options[:calculator].calculate(val1, val2, options)
+        next { distance: distance.to_f, weight: options[:weight] } unless distance.nil?
 
         nil
       end

--- a/lib/slide_rule/distance_calculators/day_of_month.rb
+++ b/lib/slide_rule/distance_calculators/day_of_month.rb
@@ -7,7 +7,7 @@ module SlideRule
       # Calculates distance using 15 as the max point.
       #   Does not take into account the number of days in the actual month being considered.
       #
-      def calculate(first, second)
+      def calculate(first, second, options={})
         return nil if first.nil? || second.nil?
         first = cleanse_date(first)
         second = cleanse_date(second)

--- a/lib/slide_rule/distance_calculators/day_of_year.rb
+++ b/lib/slide_rule/distance_calculators/day_of_year.rb
@@ -3,15 +3,15 @@ module SlideRule
     class DayOfYear
       DAYS_IN_YEAR = 365
 
-      def calculate(date_1, date_2)
+      def calculate(date_1, date_2, options={})
         date_1 = cleanse_date(date_1)
         date_2 = cleanse_date(date_2)
-
+        threshold = options[:threshold] || DAYS_IN_YEAR
         days_apart = (date_1.mjd - date_2.mjd).abs
+        
+        return 1 if days_apart >= threshold
 
-        return 1 if days_apart >= DAYS_IN_YEAR
-
-        distance = days_apart.to_f / DAYS_IN_YEAR
+        distance = days_apart.to_f / threshold
         distance.round(2)
       end
 

--- a/lib/slide_rule/distance_calculators/levenshtein.rb
+++ b/lib/slide_rule/distance_calculators/levenshtein.rb
@@ -1,7 +1,7 @@
 module SlideRule
   module DistanceCalculators
     class Levenshtein
-      def calculate(first, second)
+      def calculate(first, second, options={})
         ::Vladlev.get_normalized_distance(first, second).to_f
 
         # Lower bound is difference in length

--- a/spec/slide_rule/distance_calculator_spec.rb
+++ b/spec/slide_rule/distance_calculator_spec.rb
@@ -14,13 +14,13 @@ describe ::SlideRule::DistanceCalculator do
   end
 
   class CustomCalc
-    def calculate(_first, _second)
+    def calculate(_first, _second, _rule)
       0.9
     end
   end
 
   class NilCalc
-    def calculate(_first, _second)
+    def calculate(_first, _second, _rule)
       nil
     end
   end

--- a/spec/slide_rule/distance_calculator_spec.rb
+++ b/spec/slide_rule/distance_calculator_spec.rb
@@ -14,13 +14,13 @@ describe ::SlideRule::DistanceCalculator do
   end
 
   class CustomCalc
-    def calculate(_first, _second, _rule)
+    def calculate(_first, _second, _options)
       0.9
     end
   end
 
   class NilCalc
-    def calculate(_first, _second, _rule)
+    def calculate(_first, _second, _options)
       nil
     end
   end

--- a/spec/slide_rule/distance_calculators/day_of_year_spec.rb
+++ b/spec/slide_rule/distance_calculators/day_of_year_spec.rb
@@ -22,4 +22,17 @@ describe ::SlideRule::DistanceCalculators::DayOfYear do
       expect(described_class.new.calculate('2015-10-8', '2015-11-8')).to eq(0.08)
     end
   end
+
+  context 'when there is a threshold' do
+     it 'should return a 1 distance when there are too many days apart' do
+      expect(described_class.new.calculate('2016-02-03', '2016-03-09', :threshold => 30)).to eq(1)
+     end
+
+     it 'should return a more sane number' do
+      result_with_threshold = described_class.new.calculate('2016-02-03', '2016-02-10', :threshold => 30)
+      result_without_threshold = described_class.new.calculate('2016-02-03', '2016-02-10')
+      
+      expect(result_with_threshold).to be > result_without_threshold
+     end
+  end
 end


### PR DESCRIPTION
We're adding this options hash so we can start adding thresholds to some of the calculators. This came about because the results of the day_of_year calculator needed sanity.

@mattnichols @abrandoned @liveh2o @abrandoned @mmmries 
